### PR TITLE
Support local.properties for api credentials

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,15 +19,21 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        // Support both local.properties or ~/.gradle/gradle.properties
+        def properties = new Properties()
+        if (rootProject.file("local.properties").exists()) {
+            properties.load(rootProject.file("local.properties").newDataInputStream())
+        }
         buildConfigField(
                 "String",
                 "ASTROBIN_API_KEY",
-                "\"" + property("ASTROBIN_API_KEY") + "\""
+                "\"${properties["ASTROBIN_API_KEY"] ?: property("ASTROBIN_API_KEY")}\""
         )
         buildConfigField(
                 "String",
                 "ASTROBIN_API_SECRET",
-                "\"" + property("ASTROBIN_API_SECRET") + "\""
+                "\"${properties["ASTROBIN_API_SECRET"] ?: property("ASTROBIN_API_SECRET")}\""
         )
     }
 


### PR DESCRIPTION
Load from local.properties file if it exists, falling back to the existing global ~/.gradle/gradle.properties if not.