### PR TITLE
Upgrade Compose to 1.9 with BOM 2025.08.00

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,9 +63,6 @@ android {
         compose true
         buildConfig true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion compose_compiler_version
-    }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
@@ -75,33 +72,51 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'com.github.bumptech.glide:glide:4.12.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
-    implementation 'androidx.activity:activity-compose:1.4.0'
-    implementation "androidx.navigation:navigation-fragment-ktx:2.5.0-alpha04"
-    implementation "androidx.navigation:navigation-ui-ktx:2.5.0-alpha04"
-    implementation "androidx.navigation:navigation-compose:2.5.0-alpha04"
-    implementation "androidx.paging:paging-compose:1.0.0-alpha14"
-    implementation "com.google.accompanist:accompanist-flowlayout:0.20.2"
-    implementation "com.google.accompanist:accompanist-insets-ui:0.20.2"
-    implementation "com.squareup.retrofit2:retrofit:2.9.0"
-    implementation "com.squareup.moshi:moshi:1.11.0"
-    implementation "com.squareup.moshi:moshi-kotlin:1.11.0"
-    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
-    implementation "io.coil-kt:coil-compose:1.4.0"
+    // Compose BOM - manages all Compose library versions
+    implementation platform('androidx.compose:compose-bom:2025.08.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2025.08.00')
+
+    // Core Android
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.7'
+    implementation 'androidx.activity:activity-compose:1.9.3'
+
+    // Compose (versions managed by BOM)
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.material:material-icons-extended"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation "androidx.compose.foundation:foundation"
+
+    // Navigation
+    implementation "androidx.navigation:navigation-fragment-ktx:2.8.4"
+    implementation "androidx.navigation:navigation-ui-ktx:2.8.4"
+    implementation "androidx.navigation:navigation-compose:2.8.4"
+
+    // Paging
+    implementation 'androidx.paging:paging-common-ktx:3.3.4'
+    implementation "androidx.paging:paging-compose:3.3.4"
+
+    // Image loading
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
+    implementation "io.coil-kt:coil-compose:2.7.0"
+
+    // Networking
+    implementation "com.squareup.retrofit2:retrofit:2.11.0"
+    implementation "com.squareup.moshi:moshi:1.15.1"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.retrofit2:converter-moshi:2.11.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
+
+    // Dependency Injection
     implementation "com.google.dagger:hilt-android:$hilt_version"
-    implementation 'androidx.paging:paging-common-ktx:3.1.1'
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
+
+    // Testing
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
 }

--- a/app/src/main/java/com/example/astrobin/AstrobinUi.kt
+++ b/app/src/main/java/com/example/astrobin/AstrobinUi.kt
@@ -38,10 +38,6 @@ import com.example.astrobin.ui.screens.*
 import com.example.astrobin.ui.theme.AstrobinTheme
 import com.example.astrobin.ui.theme.DarkBlue
 import com.example.astrobin.ui.theme.Yellow
-import com.google.accompanist.insets.ProvideWindowInsets
-import com.google.accompanist.insets.navigationBarsPadding
-import com.google.accompanist.insets.statusBarsHeight
-import com.google.accompanist.insets.statusBarsPadding
 
 @Composable fun Astrobin(api: Astrobin, imageLoader: ImageLoader) {
   CompositionLocalProvider(
@@ -233,49 +229,47 @@ private enum class AstroScaffoldLayoutContent { TopBar, MainContent, BottomBar }
   bottom: @Composable () -> Unit,
   content: @Composable (PaddingValues) -> Unit
 ) {
-  ProvideWindowInsets {
-    CompositionLocalProvider(
-      LocalContentColor provides Color.White,
-    ) {
-      SubcomposeLayout(
-        modifier.background(mainWindowGradient)
-      ) { constraints ->
-        val layoutWidth = constraints.maxWidth
-        val layoutHeight = constraints.maxHeight
+  CompositionLocalProvider(
+    LocalContentColor provides Color.White,
+  ) {
+    SubcomposeLayout(
+      modifier.background(mainWindowGradient)
+    ) { constraints ->
+      val layoutWidth = constraints.maxWidth
+      val layoutHeight = constraints.maxHeight
 
-        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+      val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
 
-        layout(layoutWidth, layoutHeight) {
-          val topBarPlaceables = subcompose(AstroScaffoldLayoutContent.TopBar, top)
-            .map { it.measure(looseConstraints) }
+      layout(layoutWidth, layoutHeight) {
+        val topBarPlaceables = subcompose(AstroScaffoldLayoutContent.TopBar, top)
+          .map { it.measure(looseConstraints) }
 
-          // hard code to 0 as we want the top bar to "float" on top of things
-          val topBarHeight = 0 // topBarPlaceables.maxByOrNull { it.height }?.height ?: 0
+        // hard code to 0 as we want the top bar to "float" on top of things
+        val topBarHeight = 0 // topBarPlaceables.maxByOrNull { it.height }?.height ?: 0
 
-          val bottomBarPlaceables = subcompose(AstroScaffoldLayoutContent.BottomBar, bottom)
-            .map { it.measure(looseConstraints) }
+        val bottomBarPlaceables = subcompose(AstroScaffoldLayoutContent.BottomBar, bottom)
+          .map { it.measure(looseConstraints) }
 
-          val bottomBarHeight = bottomBarPlaceables.maxByOrNull { it.height }?.height ?: 0
+        val bottomBarHeight = bottomBarPlaceables.maxByOrNull { it.height }?.height ?: 0
 
-          val bodyContentHeight = layoutHeight - topBarHeight
+        val bodyContentHeight = layoutHeight - topBarHeight
 
-          val bodyContentPlaceables = subcompose(AstroScaffoldLayoutContent.MainContent) {
-            val innerPadding = PaddingValues(bottom = bottomBarHeight.toDp())
-            content(innerPadding)
-          }.map { it.measure(looseConstraints.copy(maxHeight = bodyContentHeight)) }
+        val bodyContentPlaceables = subcompose(AstroScaffoldLayoutContent.MainContent) {
+          val innerPadding = PaddingValues(bottom = bottomBarHeight.toDp())
+          content(innerPadding)
+        }.map { it.measure(looseConstraints.copy(maxHeight = bodyContentHeight)) }
 
-          // Placing to control drawing order to match default elevation of each placeable
+        // Placing to control drawing order to match default elevation of each placeable
 
-          bodyContentPlaceables.forEach {
-            it.place(0, topBarHeight)
-          }
-          topBarPlaceables.forEach {
-            it.place(0, 0)
-          }
-          // The bottom bar is always at the bottom of the layout
-          bottomBarPlaceables.forEach {
-            it.place(0, layoutHeight - bottomBarHeight)
-          }
+        bodyContentPlaceables.forEach {
+          it.place(0, topBarHeight)
+        }
+        topBarPlaceables.forEach {
+          it.place(0, 0)
+        }
+        // The bottom bar is always at the bottom of the layout
+        bottomBarPlaceables.forEach {
+          it.place(0, layoutHeight - bottomBarHeight)
         }
       }
     }

--- a/app/src/main/java/com/example/astrobin/ui/components/AstroImageRow.kt
+++ b/app/src/main/java/com/example/astrobin/ui/components/AstroImageRow.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.api.AstroImage
 import com.example.astrobin.api.TopPickV2
 
@@ -46,7 +46,7 @@ fun AstroImage(
   modifier: Modifier = Modifier,
 ) {
   Image(
-    painter = rememberImagePainter(imageUrl),
+    painter = rememberAsyncImagePainter(imageUrl),
     contentDescription = "",
     contentScale = ContentScale.FillWidth,
     // Bug here if I don't specify a size, I want fillWidth(). :(

--- a/app/src/main/java/com/example/astrobin/ui/components/UserViews.kt
+++ b/app/src/main/java/com/example/astrobin/ui/components/UserViews.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.api.AstroUser
 import com.example.astrobin.api.AstroUserProfile
 import com.example.astrobin.api.avatarUrl
@@ -81,7 +81,7 @@ fun SmallUserRow(
   imageUrl: String
 ) {
   Image(
-    painter = rememberImagePainter(imageUrl),
+    painter = rememberAsyncImagePainter(imageUrl),
     contentDescription = "",
     modifier = Modifier
       .border(2.dp, Yellow, CircleShape)

--- a/app/src/main/java/com/example/astrobin/ui/screens/FullScreen.kt
+++ b/app/src/main/java/com/example/astrobin/ui/screens/FullScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.ui.components.*
 
 @Composable
@@ -59,7 +59,7 @@ fun FullScreen(
       }
       .background(Color.Black)
   ) {
-    val regularPainter = rememberImagePainter(hd)
+    val regularPainter = rememberAsyncImagePainter(hd)
     Image(
       modifier = Modifier
         .fillMaxWidth()
@@ -70,7 +70,7 @@ fun FullScreen(
       contentDescription = "Full Image",
     )
     if (solution != null) {
-      val annotatedPainter = rememberImagePainter(solution)
+      val annotatedPainter = rememberAsyncImagePainter(solution)
       if (annotations) {
         Image(
           modifier = Modifier

--- a/app/src/main/java/com/example/astrobin/ui/screens/ImageScreen.kt
+++ b/app/src/main/java/com/example/astrobin/ui/screens/ImageScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.ui.Alignment
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
@@ -27,11 +28,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.api.*
 import com.example.astrobin.exp.load
 import com.example.astrobin.ui.components.*
-import com.google.accompanist.flowlayout.FlowRow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -109,8 +109,8 @@ fun ImageScreen(
   LazyColumn(Modifier.fillMaxSize(), contentPadding = padding) {
     if (image != null) {
       item {
-        val regularPainter = rememberImagePainter(image.url_regular)
-        val annotatedPainter = rememberImagePainter(plateSolve?.image_file)
+        val regularPainter = rememberAsyncImagePainter(image.url_regular)
+        val annotatedPainter = rememberAsyncImagePainter(plateSolve?.image_file)
         Box {
           Image(
             modifier = Modifier
@@ -207,7 +207,10 @@ fun ImageScreen(
       if (plateSolve != null) {
         item {
           Section("What is this") {
-            FlowRow(mainAxisSpacing = 10.dp, crossAxisSpacing = 4.dp) {
+            FlowRow(
+              horizontalArrangement = Arrangement.spacedBy(10.dp),
+              verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
               for (subject in plateSolve.objects_in_field.split(","))
                 Chip(subject.trim(), onClick = { nav.navigate("search?q=${subject.trim().urlEncode()}")})
             }
@@ -246,7 +249,7 @@ fun ImageScreen(
               modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f),
-              painter = rememberImagePainter(plateSolve.skyplot_zoom1),
+              painter = rememberAsyncImagePainter(plateSolve.skyplot_zoom1),
               contentScale = ContentScale.FillWidth,
               contentDescription = "Sky Plot",
             )
@@ -260,7 +263,7 @@ fun ImageScreen(
             modifier = Modifier
               .fillMaxWidth()
               .aspectRatio(274f / 120f),
-            painter = rememberImagePainter(image.url_histogram),
+            painter = rememberAsyncImagePainter(image.url_histogram),
             contentScale = ContentScale.FillWidth,
             contentDescription = "Histogram",
           )

--- a/app/src/main/java/com/example/astrobin/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/example/astrobin/ui/screens/SearchScreen.kt
@@ -27,14 +27,13 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.items
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.api.AstroImage
 import com.example.astrobin.api.ImageSearchPagingSource
 import com.example.astrobin.api.LocalAstrobinApi
 import com.example.astrobin.ui.components.ImageRow
 import com.example.astrobin.ui.components.LoadingIndicator
 import com.example.astrobin.ui.components.SearchBox
-import com.google.accompanist.insets.statusBarsPadding
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable

--- a/app/src/main/java/com/example/astrobin/ui/screens/TopScreen.kt
+++ b/app/src/main/java/com/example/astrobin/ui/screens/TopScreen.kt
@@ -21,8 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
-import coil.compose.rememberImagePainter
-import com.google.accompanist.insets.statusBarsPadding
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.api.*
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.items

--- a/app/src/main/java/com/example/astrobin/ui/screens/UserScreen.kt
+++ b/app/src/main/java/com/example/astrobin/ui/screens/UserScreen.kt
@@ -26,13 +26,12 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.items
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.astrobin.api.AstroUserProfile
 import com.example.astrobin.api.ImageSearchPagingSource
 import com.example.astrobin.api.LocalAstrobinApi
 import com.example.astrobin.ui.components.LoadingIndicator
 import com.example.astrobin.ui.components.UserImageRow
-import com.google.accompanist.insets.statusBarsPadding
 
 @Composable
 fun UserScreen(
@@ -104,7 +103,7 @@ private fun UserHeaderContent(user: AstroUserProfile, nav: NavController) {
   ) {
     Spacer(modifier = Modifier.height(16.dp))
     Image(
-      painter = rememberImagePainter(user.url_avatar),
+      painter = rememberAsyncImagePainter(user.url_avatar),
       contentDescription = "avatar",
       contentScale = ContentScale.Crop,
       modifier = Modifier

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
 buildscript {
     ext {
-        compose_version = '1.7.0'
-        compose_compiler_version = '1.7.0'
         hilt_version = '2.55'
     }
 }


### PR DESCRIPTION
- Use Compose BOM 2025.08.00 for consistent version management
- Update all Compose dependencies to use BOM (removes version specifiers)
- Remove deprecated accompanist libraries (flowlayout, insets-ui)
  - Migrate FlowRow to official androidx.compose.foundation.layout
  - Remove ProvideWindowInsets (no longer needed)
  - Insets modifiers now from standard Compose Foundation
- Update Coil from 1.4.0 to 2.7.0
  - Migrate rememberImagePainter to rememberAsyncImagePainter
- Update other dependencies:
  - core-ktx: 1.7.0 → 1.15.0
  - lifecycle-runtime-ktx: 2.4.1 → 2.8.7
  - activity-compose: 1.4.0 → 1.9.3
  - navigation: 2.5.0-alpha04 → 2.8.4
  - paging: 1.0.0-alpha14 → 3.3.4
  - retrofit: 2.9.0 → 2.11.0
  - moshi: 1.11.0 → 1.15.1
  - okhttp: 4.9.0 → 4.12.0
  - glide: 4.12.0 → 4.16.0
- Remove composeOptions block (not needed with Kotlin 2.0+)